### PR TITLE
Add facilities for incremental parsing

### DIFF
--- a/csrc/tree.c
+++ b/csrc/tree.c
@@ -237,6 +237,8 @@ static int tree_get_changed_ranges(lua_State *L) {
 		lua_rawseti(L, -2, i + 1); // { range }
 	}
 
+	free(ranges);
+
 	return 1;
 }
 

--- a/spec/tree_spec.lua
+++ b/spec/tree_spec.lua
@@ -20,4 +20,22 @@ describe("Tree", function()
 			"ltreesitter.Node"
 		)
 	end)
+	it("get_changed_ranges should return changed ranges", function()
+		t:edit_s {
+			start_byte    = 18,
+			old_end_byte  = 18,
+			new_end_byte  = 25,
+			start_point   = { row = 0, column = 18 },
+			old_end_point = { row = 0, column = 18 },
+			new_end_point = { row = 0, column = 25 },
+		}
+		local u = p:parse_string([[ int main(void) { int a; return 0; } ]], t)
+		local c = t:get_changed_ranges(u)
+		assert.are.same({{
+			start_byte  = 18,
+			end_byte    = 24,
+			start_point = { row = 0, column = 18 },
+			end_point   = { row = 0, column = 24 },
+		}}, c)
+	end)
 end)


### PR DESCRIPTION
Added `Tree.get_changed_ranges` — allows comparison of two trees to know the ranges of nodes that changed.
Added optional `start` and `end` parameters to `Query.{match,capture,exec}` — sets the query cursor to be within the specified range.

These changes should allow the incremental parsing TS provides to be better taken advantage of, as users can now incrementally update the information they get from queries.