### PR TITLE
Don't raise a segmentation fault when calling named_child

### DIFF
--- a/csrc/node.c
+++ b/csrc/node.c
@@ -156,7 +156,7 @@ static int node_child_count(lua_State *L) {
 static int node_named_child(lua_State *L) {
 	ltreesitter_Node *parent = ltreesitter_check_node(L, 1);
 	const uint32_t idx = luaL_checknumber(L, 2);
-	if (idx >= ts_node_child_count(parent->node)) {
+	if (idx >= ts_node_named_child_count(parent->node)) {
 		lua_pushnil(L);
 	} else {
 		push_parent(L, 1);


### PR DESCRIPTION
This script will segfault:
```lua
#!/usr/bin/env lua

ltreesitter = require"ltreesitter"
json = ltreesitter.require"json"
tree = json:parse_string('{"a": 1, "b": 2, "c": 3}')

print(tree:root():child(0):named_child(3))
```
The number of named children is 3, but the number of children is 7. So using indexes between 3 and 7 will result in a segmentation fault. Using indexes above 7 will print nil as expected
The grammar used is https://github.com/tree-sitter/tree-sitter-json/tree/73076754005a460947cafe8e03a8cf5fa4fa2938