### PR TITLE
module: export luaopen_ltreesitter explicitly on Windows

### DIFF
--- a/csrc/ltreesitter.c
+++ b/csrc/ltreesitter.c
@@ -3,6 +3,7 @@
 
 #include "luautils.h"
 #include "object.h"
+#include <ltreesitter/module.h>
 #include <ltreesitter/dynamiclib.h>
 #include <ltreesitter/node.h>
 #include <ltreesitter/parser.h>
@@ -21,7 +22,7 @@ static const luaL_Reg lib_funcs[] = {
 	{NULL, NULL},
 };
 
-LUA_API int luaopen_ltreesitter(lua_State *L) {
+LTREESITTER_EXPORT int luaopen_ltreesitter(lua_State *L) {
 	ltreesitter_create_parser_metatable(L);
 	ltreesitter_create_tree_metatable(L);
 	ltreesitter_create_tree_cursor_metatable(L);

--- a/include/ltreesitter/module.h
+++ b/include/ltreesitter/module.h
@@ -3,6 +3,12 @@
 
 #include <lua.h>
 
-LUA_API int luaopen_ltreesitter(lua_State *L);
+#ifdef _WIN32
+#define LTREESITTER_EXPORT __declspec (dllexport)
+#else
+#define LTREESITTER_EXPORT
+#endif
+
+LTREESITTER_EXPORT int luaopen_ltreesitter(lua_State *L);
 
 #endif // LTREESITTER_LTREESITTER_H

--- a/include/ltreesitter/module.h
+++ b/include/ltreesitter/module.h
@@ -6,7 +6,7 @@
 #ifdef _WIN32
 #define LTREESITTER_EXPORT __declspec (dllexport)
 #else
-#define LTREESITTER_EXPORT
+#define LTREESITTER_EXPORT __attribute__ ((visibility("default")))
 #endif
 
 LTREESITTER_EXPORT int luaopen_ltreesitter(lua_State *L);


### PR DESCRIPTION
This PR exports the `luaopen_ltreesitter` symbol properly on Windows when compiling as a DLL.