### PR TITLE
fix(dynamiclib): invalid function pointer to data pointer conversion

### DIFF
--- a/csrc/dynamiclib.c
+++ b/csrc/dynamiclib.c
@@ -18,7 +18,8 @@ bool ltreesitter_open_dynamic_lib(const char *name, ltreesitter_Dynlib **handle)
 
 void *ltreesitter_dynamic_sym(ltreesitter_Dynlib *handle, const char *sym_name) {
 #ifdef _WIN32
-	return GetProcAddress(handle, sym_name);
+	FARPROC sym = GetProcAddress(handle, sym_name);
+	return *(void**)(&sym);
 #elif LTREESITTER_USE_LIBUV
 	void *sym = NULL;
 	if (uv_dlsym(handle, sym_name, &sym) == 0) {


### PR DESCRIPTION
When compiling ltreesitter on Windows with all the warnings enabled (based on the Makefile), the line with GetProcAddress throws an error. This is because it actually returns a FARPROC (a function pointer type) and the function returns a void pointer (a data pointer type), and such conversion are illegal in ISO C. POSIX implicitly guarantees this.

This PR instead use double casting to return a void pointer. This isn't beautiful, but it tricks the compiler to thinking that it's valid ISO C.