### PR TITLE
Add tree sitter library as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tree-sitter"]
+	path = tree-sitter
+	url = https://github.com/tree-sitter/tree-sitter

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Tree sitter bindings for Lua
 
+Current tree-sitter version: v0.24.4
+
 # Documentation
 
 Documentation can be found at [this repo's github pages](https://euclidianace.github.io/ltreesitter/)

--- a/rockspec/ltreesitter-0.0.7-1.rockspec
+++ b/rockspec/ltreesitter-0.0.7-1.rockspec
@@ -12,14 +12,7 @@ description = {
    detailed = [[Standalone Lua bindings to the Treesitter api (with full type definitions for Teal).]],
    issues_url = "https://github.com/euclidianAce/ltreesitter/issues",
 }
-external_dependencies = {
-   TREE_SITTER = {
-      header = "tree_sitter/api.h",
-   },
-   -- UV = {
-      -- header = "uv.h",
-   -- }
-}
+
 build = {
 	type = "builtin",
    modules = {
@@ -36,10 +29,9 @@ build = {
             "csrc/parser.c",
             "csrc/query_cursor.c",
             "csrc/tree_cursor.c",
+	    "tree-sitter/lib/src/lib.c",
          },
-         incdirs = { "include", "$(TREE_SITTER_INCDIR)" },
-         libraries = { "tree-sitter" },
-         libdirs = { "$(TREE_SITTER_LIBDIR)" },
+         incdirs = { "include", "tree-sitter/lib/include" },
       },
    },
    copy_directories = {


### PR DESCRIPTION
Will not require that the tree-sitter lib is installed to use the bindings any longer.

Bundles in v0.24.4. 

closes #29 